### PR TITLE
Add fallback to docker logs if systemd-journal-gatewayd Unix socket is not available

### DIFF
--- a/supervisor/api/supervisor.py
+++ b/supervisor/api/supervisor.py
@@ -45,7 +45,7 @@ from ..const import (
     UpdateChannel,
 )
 from ..coresys import CoreSysAttributes
-from ..exceptions import APIError
+from ..exceptions import APIError, HostNotSupportedError
 from ..store.validate import repositories
 from ..utils.sentry import close_sentry, init_sentry
 from ..utils.validate import validate_timezone
@@ -231,6 +231,12 @@ class APISupervisor(CoreSysAttributes):
         return asyncio.shield(self.sys_supervisor.restart())
 
     @api_process_raw(CONTENT_TYPE_TEXT, error_type=CONTENT_TYPE_TEXT)
-    def logs(self, request: web.Request) -> Awaitable[bytes]:
+    async def logs(self, request: web.Request) -> bytes:
         """Return supervisor Docker logs."""
-        return self.sys_supervisor.logs()
+        try:
+            return await self.sys_supervisor.logs()
+        except HostNotSupportedError:
+            _LOGGER.warning(
+                "systemd-journal-gatewayd Unix socket is not available, falling back to Docker logs"
+            )
+            return await self.sys_supervisor.instance.get_logs()

--- a/supervisor/docker/supervisor.py
+++ b/supervisor/docker/supervisor.py
@@ -124,3 +124,7 @@ class DockerSupervisor(DockerInterface):
 
         except (docker.errors.DockerException, requests.RequestException) as err:
             raise DockerError(f"Can't fix start tag: {err}", _LOGGER.error) from err
+
+    async def get_logs(self) -> bytes:
+        """Fetch Docker logs."""
+        return await self.sys_run_in_executor(self.sys_docker.container_logs, self.name)

--- a/supervisor/host/logs.py
+++ b/supervisor/host/logs.py
@@ -189,3 +189,7 @@ class LogsControl(CoreSysAttributes):
             raise HostServiceError(
                 "Unable to connect to systemd-journal-gatewayd", _LOGGER.error
             ) from ex
+
+    async def get_docker_logs(self) -> bytes:
+        """Fetch Docker logs."""
+        return await self.sys_supervisor.instance.get_logs()


### PR DESCRIPTION
Add a fallback mechanism to Docker logs if `systemd-journal-gatewayd` Unix socket is unavailable.

* **supervisor/api/supervisor.py**
  - Import `HostNotSupportedError` from `supervisor.exceptions`.
  - Modify `logs` method to use Docker logs if `systemd-journal-gatewayd` Unix socket is unavailable.

* **supervisor/host/logs.py**
  - Add `get_docker_logs` method to fetch Docker logs.

* **supervisor/docker/supervisor.py**
  - Add `get_logs` method to fetch Docker logs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ElD4n1/supervisor/pull/1?shareId=ee5d7077-1348-4419-906d-1d07eed9d554).